### PR TITLE
Add links to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ style blend weight of 0.2:
 
 ## Requirements
 
-* [TensorFlow](https://www.tensorflow.org/versions/r0.11/get_started/os_setup.html#download-and-setup)
+* [TensorFlow](https://www.tensorflow.org/versions/master/get_started/os_setup.html#download-and-setup)
 * [NumPy](https://github.com/numpy/numpy/blob/master/INSTALL.rst.txt)
 * [SciPy](https://github.com/scipy/scipy/blob/master/INSTALL.rst.txt)
 * [Pillow](http://pillow.readthedocs.io/en/3.3.x/installation.html#installation)

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ style blend weight of 0.2:
 
 ## Requirements
 
-* TensorFlow
-* SciPy
+* [TensorFlow](https://www.tensorflow.org/versions/r0.11/get_started/os_setup.html#download-and-setup)
+* [NumPy](https://github.com/numpy/numpy/blob/master/INSTALL.rst.txt)
+* [SciPy](https://github.com/scipy/scipy/blob/master/INSTALL.rst.txt)
 * Pillow
-* NumPy
 * [Pre-trained VGG network][net] (MD5 `8ee3263992981a1d26e73b3ca028a123`)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ style blend weight of 0.2:
 * [TensorFlow](https://www.tensorflow.org/versions/r0.11/get_started/os_setup.html#download-and-setup)
 * [NumPy](https://github.com/numpy/numpy/blob/master/INSTALL.rst.txt)
 * [SciPy](https://github.com/scipy/scipy/blob/master/INSTALL.rst.txt)
-* Pillow
-* [Pre-trained VGG network][net] (MD5 `8ee3263992981a1d26e73b3ca028a123`)
+* [Pillow](http://pillow.readthedocs.io/en/3.3.x/installation.html#installation)
+* [Pre-trained VGG network][net] (MD5 `8ee3263992981a1d26e73b3ca028a123`) - put it in the top level of this repository
 
 ## License
 


### PR DESCRIPTION
## Changes:

 - Add links to installation instructions for the dependencies.
 - Reorder Numpy to be before Scipy, since it seems to be required first.
 - Document to put the "Pre-trained VGG network" into this repository.

## Other thoughts:

Wow it was hard to install all these dependencies on a Mac OSX 10.10.5!  There were some other dependencies that I needed to manually install to get the other dependencies to work:
```
pip install pbr funcsigs
brew install gcc
```

I also needed this answer to help me get Scipy installed:
http://stackoverflow.com/a/4495175/112705
