### PR TITLE
Added lbfgs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@ An implementation of [neural style][paper] in TensorFlow.
 This implementation is a lot simpler than a lot of the other ones out there,
 thanks to TensorFlow's really nice API and [automatic differentiation][ad].
 
-TensorFlow doesn't support [L-BFGS][l-bfgs] (which is what the original authors
-used), so we use [Adam][adam]. This may require a little bit more
-hyperparameter tuning to get nice results.
-
 TensorFlow seems to be [slower][tensorflow-benchmarks] than a lot of the other
 deep learning frameworks out there. I'm sure this implementation could be
 improved, but it would probably take improvements in TensorFlow itself as well

--- a/neural_style.py
+++ b/neural_style.py
@@ -5,8 +5,6 @@ import os
 import numpy as np
 import scipy.misc
 
-from stylize import stylize
-
 import math
 from argparse import ArgumentParser
 
@@ -17,6 +15,7 @@ TV_WEIGHT = 1e2
 LEARNING_RATE = 1e1
 STYLE_SCALE = 1.0
 ITERATIONS = 1000
+OPTIMIZER = 'lbfgs'
 VGG_PATH = 'imagenet-vgg-verydeep-19.mat'
 
 
@@ -32,6 +31,9 @@ def build_parser():
     parser.add_argument('--output',
             dest='output', help='output path',
             metavar='OUTPUT', required=True)
+    parser.add_argument('--optimizer',
+            dest='optimizer', help='lbfgs or adam (default %(default)s)',
+            metavar='OPTIMIZER', default=OPTIMIZER)
     parser.add_argument('--iterations', type=int,
             dest='iterations', help='iterations (default %(default)s)',
             metavar='ITERATIONS', default=ITERATIONS)
@@ -84,6 +86,7 @@ def main():
 
     content_image = imread(options.content)
     style_images = [imread(style) for style in options.styles]
+    optimizer = options.optimizer
 
     width = options.width
     if width is not None:
@@ -115,11 +118,14 @@ def main():
         parser.error("To save intermediate images, the checkpoint output "
                      "parameter must contain `%s` (e.g. `foo%s.jpg`)")
 
+    from stylize import stylize
+
     for iteration, image in stylize(
         network=options.network,
         initial=initial,
         content=content_image,
         styles=style_images,
+        optimizer=optimizer,
         iterations=options.iterations,
         content_weight=options.content_weight,
         style_weight=options.style_weight,


### PR DESCRIPTION
- b1ad968 is to prevent showing

```
I tensorflow/stream_executor/dso_loader.cc:116] successfully opened CUDA library libcublas.so locally
I tensorflow/stream_executor/dso_loader.cc:116] successfully opened CUDA library libcudnn.so.5 locally
I tensorflow/stream_executor/dso_loader.cc:116] successfully opened CUDA library libcufft.so locally
I tensorflow/stream_executor/dso_loader.cc:116] successfully opened CUDA library libcuda.so.1 locally
I tensorflow/stream_executor/dso_loader.cc:116] successfully opened CUDA library libcurand.so locally
```

when running `python neural_style.py --help`
- 8d5e44c still has a problem to discuss. I will describe it in the reviews.
