### PR TITLE
Several tweaks for style transfer

### DIFF
--- a/neural_style.py
+++ b/neural_style.py
@@ -16,8 +16,9 @@ import tensorflow as tf
 
 # default arguments
 CONTENT_WEIGHT = 5e0
-STYLE_WEIGHT = 1e2
+STYLE_WEIGHT = 5e2
 TV_WEIGHT = 1e2
+STYLE_LAYER_WEIGHT_EXP = 1
 LEARNING_RATE = 1e1
 BETA1 = 0.9
 BETA2 = 0.999
@@ -67,6 +68,9 @@ def build_parser():
     parser.add_argument('--style-weight', type=float,
             dest='style_weight', help='style weight (default %(default)s)',
             metavar='STYLE_WEIGHT', default=STYLE_WEIGHT)
+    parser.add_argument('--style-layer-weight-exp', type=float,
+            dest='style_layer_weight_exp', help='style layer weight exponentional increase - weight(layer<n+1>) = weight_exp*weight(layer<n>) (default %(default)s)',
+            metavar='STYLE_LAYER_WEIGHT_EXP', default=STYLE_LAYER_WEIGHT_EXP)
     parser.add_argument('--style-blend-weights', type=float,
             dest='style_blend_weights', help='style blending weights',
             nargs='+', metavar='STYLE_BLEND_WEIGHT')
@@ -142,6 +146,7 @@ def main():
         iterations=options.iterations,
         content_weight=options.content_weight,
         style_weight=options.style_weight,
+        style_layer_weight_exp=options.style_layer_weight_exp,
         style_blend_weights=style_blend_weights,
         tv_weight=options.tv_weight,
         learning_rate=options.learning_rate,

--- a/neural_style.py
+++ b/neural_style.py
@@ -27,7 +27,7 @@ EPSILON = 1e-08
 STYLE_SCALE = 1.0
 ITERATIONS = 1000
 VGG_PATH = 'imagenet-vgg-verydeep-19.mat'
-PRESERVE_COLORS = 0
+PRESERVE_COLORS = False
 POOLING = 'max'
 
 def build_parser():
@@ -100,9 +100,8 @@ def build_parser():
     parser.add_argument('--initial-noiseblend', type=float,
             dest='initial_noiseblend', help='ratio of blending initial image with normalized noise (if no initial image specified, content image is used) (default %(default)s)',
             metavar='INITIAL_NOISEBLEND')
-    parser.add_argument('--preserve-colors', type=int,
-            dest='preserve_colors', help='style-only transfer (preserving colors): 1 if color transfer is not needed (default %(default)s)',
-            metavar='PRESERVE_COLORS', default=PRESERVE_COLORS)
+    parser.add_argument('--preserve-colors', action='store_true',
+            dest='preserve_colors', help='style-only transfer (preserving colors) - if color transfer is not needed')
     parser.add_argument('--pooling',
             dest='pooling', help='pooling layer configuration: max or avg (default %(default)s)',
             metavar='POOLING', default=POOLING)
@@ -185,7 +184,7 @@ def main():
             if options.checkpoint_output:
                 output_file = options.checkpoint_output % iteration
         else:
-            if options.preserve_colors == 1:
+            if options.preserve_colors == True:
                 original_image = tf.placeholder("float", [1, content_image.shape[0], content_image.shape[1], content_image.shape[2]])
                 styled_image = tf.placeholder("float", [1, image.shape[0], image.shape[1], image.shape[2]])            
 

--- a/neural_style.py
+++ b/neural_style.py
@@ -17,6 +17,9 @@ CONTENT_WEIGHT = 5e0
 STYLE_WEIGHT = 1e2
 TV_WEIGHT = 1e2
 LEARNING_RATE = 1e1
+BETA1 = 0.9
+BETA2 = 0.999
+EPSILON = 1e-08
 STYLE_SCALE = 1.0
 ITERATIONS = 1000
 VGG_PATH = 'imagenet-vgg-verydeep-19.mat'
@@ -71,6 +74,15 @@ def build_parser():
     parser.add_argument('--learning-rate', type=float,
             dest='learning_rate', help='learning rate (default %(default)s)',
             metavar='LEARNING_RATE', default=LEARNING_RATE)
+    parser.add_argument('--beta1', type=float,
+            dest='beta1', help='Adam: beta1 parameter (default %(default)s)',
+            metavar='BETA1', default=BETA1)
+    parser.add_argument('--beta2', type=float,
+            dest='beta2', help='Adam: beta2 parameter (default %(default)s)',
+            metavar='BETA2', default=BETA2)
+    parser.add_argument('--eps', type=float,
+            dest='epsilon', help='Adam: epsilon parameter (default %(default)s)',
+            metavar='EPSILON', default=EPSILON)
     parser.add_argument('--initial',
             dest='initial', help='initial image',
             metavar='INITIAL')
@@ -128,6 +140,9 @@ def main():
         style_blend_weights=style_blend_weights,
         tv_weight=options.tv_weight,
         learning_rate=options.learning_rate,
+        beta1=options.beta1,
+        beta2=options.beta2,
+        epsilon=options.epsilon,
         print_iterations=options.print_iterations,
         checkpoint_iterations=options.checkpoint_iterations
     ):

--- a/neural_style.py
+++ b/neural_style.py
@@ -10,6 +10,8 @@ from stylize import stylize
 import math
 from argparse import ArgumentParser
 
+from matplotlib import pyplot as plt
+
 # default arguments
 CONTENT_WEIGHT = 5e0
 STYLE_WEIGHT = 1e2
@@ -149,7 +151,7 @@ def imread(path):
 
 def imsave(path, img):
     img = np.clip(img, 0, 255).astype(np.uint8)
-    scipy.misc.imsave(path, img)
+    plt.imsave(path, img)
 
 
 if __name__ == '__main__':

--- a/neural_style.py
+++ b/neural_style.py
@@ -10,7 +10,7 @@ from stylize import stylize
 import math
 from argparse import ArgumentParser
 
-from matplotlib import pyplot as plt
+from PIL import Image
 
 import tensorflow as tf
 
@@ -215,7 +215,7 @@ def imread(path):
 
 def imsave(path, img):
     img = np.clip(img, 0, 255).astype(np.uint8)
-    plt.imsave(path, img)
+    Image.fromarray(img).save(path, quality=95)
 
 def rgb2yuv(rgb):
     """

--- a/neural_style.py
+++ b/neural_style.py
@@ -28,6 +28,7 @@ STYLE_SCALE = 1.0
 ITERATIONS = 1000
 VGG_PATH = 'imagenet-vgg-verydeep-19.mat'
 PRESERVE_COLORS = 0
+POOLING = 'max'
 
 def build_parser():
     parser = ArgumentParser()
@@ -102,6 +103,9 @@ def build_parser():
     parser.add_argument('--preserve-colors', type=int,
             dest='preserve_colors', help='style-only transfer (preserving colors): 1 if color transfer is not needed (default %(default)s)',
             metavar='PRESERVE_COLORS', default=PRESERVE_COLORS)
+    parser.add_argument('--pooling',
+            dest='pooling', help='pooling layer configuration: max or avg (default %(default)s)',
+            metavar='POOLING', default=POOLING)
     return parser
 
 
@@ -171,6 +175,7 @@ def main():
         beta1=options.beta1,
         beta2=options.beta2,
         epsilon=options.epsilon,
+        pooling=options.pooling,
         print_iterations=options.print_iterations,
         checkpoint_iterations=options.checkpoint_iterations
     ):

--- a/neural_style.py
+++ b/neural_style.py
@@ -16,6 +16,7 @@ import tensorflow as tf
 
 # default arguments
 CONTENT_WEIGHT = 5e0
+CONTENT_WEIGHT_BLEND = 1
 STYLE_WEIGHT = 5e2
 TV_WEIGHT = 1e2
 STYLE_LAYER_WEIGHT_EXP = 1
@@ -62,6 +63,9 @@ def build_parser():
     parser.add_argument('--network',
             dest='network', help='path to network parameters (default %(default)s)',
             metavar='VGG_PATH', default=VGG_PATH)
+    parser.add_argument('--content-weight-blend', type=float,
+            dest='content_weight_blend', help='content weight blend, conv4_2 * blend + conv5_2 * (1-blend) (default %(default)s)',
+            metavar='CONTENT_WEIGHT_BLEND', default=CONTENT_WEIGHT_BLEND)
     parser.add_argument('--content-weight', type=float,
             dest='content_weight', help='content weight (default %(default)s)',
             metavar='CONTENT_WEIGHT', default=CONTENT_WEIGHT)
@@ -158,6 +162,7 @@ def main():
         styles=style_images,
         iterations=options.iterations,
         content_weight=options.content_weight,
+        content_weight_blend=options.content_weight_blend,
         style_weight=options.style_weight,
         style_layer_weight_exp=options.style_layer_weight_exp,
         style_blend_weights=style_blend_weights,

--- a/stylize.py
+++ b/stylize.py
@@ -7,6 +7,8 @@ import numpy as np
 
 from sys import stderr
 
+from PIL import Image
+
 CONTENT_LAYERS = ('relu4_2', 'relu5_2')
 STYLE_LAYERS = ('relu1_1', 'relu2_1', 'relu3_1', 'relu4_1', 'relu5_1')
 
@@ -16,7 +18,7 @@ except NameError:
     from functools import reduce
 
 
-def stylize(network, initial, initial_noiseblend, content, styles, iterations,
+def stylize(network, initial, initial_noiseblend, content, styles, preserve_colors, iterations,
         content_weight, content_weight_blend, style_weight, style_layer_weight_exp, style_blend_weights, tv_weight,
         learning_rate, beta1, beta2, epsilon, pooling,
         print_iterations=None, checkpoint_iterations=None):
@@ -154,12 +156,55 @@ def stylize(network, initial, initial_noiseblend, content, styles, iterations,
                     if this_loss < best_loss:
                         best_loss = this_loss
                         best = image.eval()
+                    
+                    img_out = vgg.unprocess(best.reshape(shape[1:]), vgg_mean_pixel)
+                    
+                    if preserve_colors and preserve_colors == True:
+                        original_image = np.clip(content, 0, 255)
+                        styled_image = np.clip(img_out, 0, 255)
+                        
+                        #The luminosity transfer steps:
+                        # 1. Convert stylized RGB->grayscale accoriding to Rec.601 luma (0.299, 0.587, 0.114)
+                        # 2. Convert stylized grayscale into YUV (YCbCr)
+                        # 3. Convert original image into YUV (YCbCr)
+                        # 4. Recombine (stylizedYUV.Y, originalYUV.U, originalYUV.V)
+                        # 5. Convert recombined image from YUV back to RGB
+                        
+                        # 1
+                        styled_grayscale = rgb2gray(styled_image)
+                        styled_grayscale_rgb = gray2rgb(styled_grayscale)
+                        # 2
+                        styled_grayscale_yuv = np.array( Image.fromarray(styled_grayscale_rgb.astype(np.uint8)).convert('YCbCr') )
+
+                        # 3
+                        original_yuv = np.array( Image.fromarray(original_image.astype(np.uint8)).convert('YCbCr') )
+                        
+                        # 4
+                        w, h, _ = original_image.shape
+                        combined_yuv = np.empty((w, h, 3), dtype=np.uint8)
+                        combined_yuv[..., 0] = styled_grayscale_yuv[..., 0]
+                        combined_yuv[..., 1] = original_yuv[..., 1]
+                        combined_yuv[..., 2] = original_yuv[..., 2]
+                        
+                        # 5
+                        img_out = np.array( Image.fromarray(combined_yuv, 'YCbCr').convert('RGB') )
+
+                        
                     yield (
                         (None if last_step else i),
-                        vgg.unprocess(best.reshape(shape[1:]), vgg_mean_pixel)
+                        img_out
                     )
 
 
 def _tensor_size(tensor):
     from operator import mul
     return reduce(mul, (d.value for d in tensor.get_shape()), 1)
+
+def rgb2gray(rgb):
+    return np.dot(rgb[...,:3], [0.299, 0.587, 0.114])
+
+def gray2rgb(gray):
+    w, h = gray.shape
+    rgb = np.empty((w, h, 3), dtype=np.float32)
+    rgb[:, :, 2] = rgb[:, :, 1] = rgb[:, :, 0] = gray
+    return rgb

--- a/stylize.py
+++ b/stylize.py
@@ -37,17 +37,17 @@ def stylize(network, initial, initial_noiseblend, content, styles, iterations,
     vgg_weights, vgg_mean_pixel = vgg.load_net(network)
     
     layer_weight = 1.0
-    STYLE_LAYERS_WEIGHTS = {}
+    style_layers_weights = {}
     for style_layer in STYLE_LAYERS:
-        STYLE_LAYERS_WEIGHTS[style_layer] = layer_weight
+        style_layers_weights[style_layer] = layer_weight
         layer_weight *= style_layer_weight_exp
     
     # normalize style layer weights
     layer_weights_sum = 0
     for style_layer in STYLE_LAYERS:
-        layer_weights_sum += STYLE_LAYERS_WEIGHTS[style_layer]
+        layer_weights_sum += style_layers_weights[style_layer]
     for style_layer in STYLE_LAYERS:
-        STYLE_LAYERS_WEIGHTS[style_layer] /= layer_weights_sum
+        style_layers_weights[style_layer] /= layer_weights_sum
     
     # compute content features in feedforward mode
     g = tf.Graph()
@@ -110,7 +110,7 @@ def stylize(network, initial, initial_noiseblend, content, styles, iterations,
                 feats = tf.reshape(layer, (-1, number))
                 gram = tf.matmul(tf.transpose(feats), feats) / size
                 style_gram = style_features[i][style_layer]
-                style_losses.append(STYLE_LAYERS_WEIGHTS[style_layer] * 2 * tf.nn.l2_loss(gram - style_gram) / style_gram.size)
+                style_losses.append(style_layers_weights[style_layer] * 2 * tf.nn.l2_loss(gram - style_gram) / style_gram.size)
             style_loss += style_weight * style_blend_weights[i] * reduce(tf.add, style_losses)
 
         # total variation denoising

--- a/stylize.py
+++ b/stylize.py
@@ -18,7 +18,7 @@ except NameError:
 
 def stylize(network, initial, initial_noiseblend, content, styles, iterations,
         content_weight, content_weight_blend, style_weight, style_layer_weight_exp, style_blend_weights, tv_weight,
-        learning_rate, beta1, beta2, epsilon,
+        learning_rate, beta1, beta2, epsilon, pooling,
         print_iterations=None, checkpoint_iterations=None):
     """
     Stylize images.
@@ -53,7 +53,7 @@ def stylize(network, initial, initial_noiseblend, content, styles, iterations,
     g = tf.Graph()
     with g.as_default(), g.device('/cpu:0'), tf.Session() as sess:
         image = tf.placeholder('float', shape=shape)
-        net = vgg.net_preloaded(vgg_weights, image)
+        net = vgg.net_preloaded(vgg_weights, image, pooling)
         content_pre = np.array([vgg.preprocess(content, vgg_mean_pixel)])
         for layer in CONTENT_LAYERS:
             content_features[layer] = net[layer].eval(feed_dict={image: content_pre})
@@ -63,7 +63,7 @@ def stylize(network, initial, initial_noiseblend, content, styles, iterations,
         g = tf.Graph()
         with g.as_default(), g.device('/cpu:0'), tf.Session() as sess:
             image = tf.placeholder('float', shape=style_shapes[i])
-            net = vgg.net_preloaded(vgg_weights, image)
+            net = vgg.net_preloaded(vgg_weights, image, pooling)
             style_pre = np.array([vgg.preprocess(styles[i], vgg_mean_pixel)])
             for layer in STYLE_LAYERS:
                 features = net[layer].eval(feed_dict={image: style_pre})
@@ -84,7 +84,7 @@ def stylize(network, initial, initial_noiseblend, content, styles, iterations,
             noise = np.random.normal(size=shape, scale=np.std(content) * 0.1)
             initial = (initial) * initial_content_noise_coeff + (tf.random_normal(shape) * 0.256) * (1.0 - initial_content_noise_coeff)
         image = tf.Variable(initial)
-        net = vgg.net_preloaded(vgg_weights, image)
+        net = vgg.net_preloaded(vgg_weights, image, pooling)
 
         # content loss
         CONTENT_LAYERS_WEIGHTS = {}

--- a/stylize.py
+++ b/stylize.py
@@ -127,24 +127,28 @@ def stylize(network, initial, initial_noiseblend, content, styles, iterations,
         # optimizer setup
         train_step = tf.train.AdamOptimizer(learning_rate, beta1, beta2, epsilon).minimize(loss)
 
-        def print_progress(i, last=False):
-            stderr.write('Iteration %d/%d\n' % (i + 1, iterations))
-            if last or (print_iterations and i % print_iterations == 0):
-                stderr.write('  content loss: %g\n' % content_loss.eval())
-                stderr.write('    style loss: %g\n' % style_loss.eval())
-                stderr.write('       tv loss: %g\n' % tv_loss.eval())
-                stderr.write('    total loss: %g\n' % loss.eval())
+        def print_progress():
+            stderr.write('  content loss: %g\n' % content_loss.eval())
+            stderr.write('    style loss: %g\n' % style_loss.eval())
+            stderr.write('       tv loss: %g\n' % tv_loss.eval())
+            stderr.write('    total loss: %g\n' % loss.eval())
 
         # optimization
         best_loss = float('inf')
         best = None
         with tf.Session() as sess:
             sess.run(tf.initialize_all_variables())
+            stderr.write('Optimization started..\n')
+            if (print_iterations and print_iterations != 0):
+                print_progress()
             for i in range(iterations):
-                last_step = (i == iterations - 1)
-                print_progress(i, last=last_step)
+                stderr.write('Iteration %4d/%4d\n' % (i + 1, iterations))
                 train_step.run()
 
+                last_step = (i == iterations - 1)
+                if last_step or (print_iterations and i % print_iterations == 0):
+                    print_progress()
+                
                 if (checkpoint_iterations and i % checkpoint_iterations == 0) or last_step:
                     this_loss = loss.eval()
                     if this_loss < best_loss:

--- a/stylize.py
+++ b/stylize.py
@@ -19,7 +19,8 @@ except NameError:
 
 def stylize(network, initial, content, styles, iterations,
         content_weight, style_weight, style_blend_weights, tv_weight,
-        learning_rate, print_iterations=None, checkpoint_iterations=None):
+        learning_rate, beta1, beta2, epsilon,
+        print_iterations=None, checkpoint_iterations=None):
     """
     Stylize images.
 
@@ -96,7 +97,7 @@ def stylize(network, initial, content, styles, iterations,
         loss = content_loss + style_loss + tv_loss
 
         # optimizer setup
-        train_step = tf.train.AdamOptimizer(learning_rate).minimize(loss)
+        train_step = tf.train.AdamOptimizer(learning_rate, beta1, beta2, epsilon).minimize(loss)
 
         def print_progress(i, last=False):
             stderr.write('Iteration %d/%d\n' % (i + 1, iterations))

--- a/stylize.py
+++ b/stylize.py
@@ -89,14 +89,14 @@ def stylize(network, initial, initial_noiseblend, content, styles, preserve_colo
         net = vgg.net_preloaded(vgg_weights, image, pooling)
 
         # content loss
-        CONTENT_LAYERS_WEIGHTS = {}
-        CONTENT_LAYERS_WEIGHTS['relu4_2'] = content_weight_blend
-        CONTENT_LAYERS_WEIGHTS['relu5_2'] = 1.0 - content_weight_blend
+        content_layers_weights = {}
+        content_layers_weights['relu4_2'] = content_weight_blend
+        content_layers_weights['relu5_2'] = 1.0 - content_weight_blend
         
         content_loss = 0
         content_losses = []
         for content_layer in CONTENT_LAYERS:
-            content_losses.append(CONTENT_LAYERS_WEIGHTS[content_layer] * content_weight * (2 * tf.nn.l2_loss(
+            content_losses.append(content_layers_weights[content_layer] * content_weight * (2 * tf.nn.l2_loss(
                     net[content_layer] - content_features[content_layer]) /
                     content_features[content_layer].size))
         content_loss += reduce(tf.add, content_losses)

--- a/vgg.py
+++ b/vgg.py
@@ -4,7 +4,7 @@ import tensorflow as tf
 import numpy as np
 import scipy.io
 
-vgg19_layers = (
+VGG19_LAYERS = (
     'conv1_1', 'relu1_1', 'conv1_2', 'relu1_2', 'pool1',
 
     'conv2_1', 'relu2_1', 'conv2_2', 'relu2_2', 'pool2',
@@ -29,7 +29,7 @@ def load_net(data_path):
 def net_preloaded(weights, input_image, pooling):
     net = {}
     current = input_image
-    for i, name in enumerate(vgg19_layers):
+    for i, name in enumerate(VGG19_LAYERS):
         kind = name[:4]
         if kind == 'conv':
             kernels, bias = weights[i][0][0][0][0]
@@ -44,7 +44,7 @@ def net_preloaded(weights, input_image, pooling):
             current = _pool_layer(current, pooling)
         net[name] = current
 
-    assert len(net) == len(vgg19_layers)
+    assert len(net) == len(VGG19_LAYERS)
     return net
 
 def _conv_layer(input, weights, bias):

--- a/vgg.py
+++ b/vgg.py
@@ -26,7 +26,7 @@ def load_net(data_path):
     weights = data['layers'][0]
     return weights, mean_pixel
 
-def net_preloaded(weights, input_image):
+def net_preloaded(weights, input_image, pooling):
     net = {}
     current = input_image
     for i, name in enumerate(vgg19_layers):
@@ -41,7 +41,7 @@ def net_preloaded(weights, input_image):
         elif kind == 'relu':
             current = tf.nn.relu(current)
         elif kind == 'pool':
-            current = _pool_layer(current)
+            current = _pool_layer(current, pooling)
         net[name] = current
 
     assert len(net) == len(vgg19_layers)
@@ -53,10 +53,13 @@ def _conv_layer(input, weights, bias):
     return tf.nn.bias_add(conv, bias)
 
 
-def _pool_layer(input):
-    return tf.nn.max_pool(input, ksize=(1, 2, 2, 1), strides=(1, 2, 2, 1),
-            padding='SAME')
-
+def _pool_layer(input, pooling):
+    if pooling == 'avg':
+        return tf.nn.avg_pool(input, ksize=(1, 2, 2, 1), strides=(1, 2, 2, 1),
+                padding='SAME')
+    else:
+        return tf.nn.max_pool(input, ksize=(1, 2, 2, 1), strides=(1, 2, 2, 1),
+                padding='SAME')
 
 def preprocess(image, mean_pixel):
     return image - mean_pixel

--- a/vgg.py
+++ b/vgg.py
@@ -4,31 +4,32 @@ import tensorflow as tf
 import numpy as np
 import scipy.io
 
+vgg19_layers = (
+    'conv1_1', 'relu1_1', 'conv1_2', 'relu1_2', 'pool1',
 
-def net(data_path, input_image):
-    layers = (
-        'conv1_1', 'relu1_1', 'conv1_2', 'relu1_2', 'pool1',
+    'conv2_1', 'relu2_1', 'conv2_2', 'relu2_2', 'pool2',
 
-        'conv2_1', 'relu2_1', 'conv2_2', 'relu2_2', 'pool2',
+    'conv3_1', 'relu3_1', 'conv3_2', 'relu3_2', 'conv3_3',
+    'relu3_3', 'conv3_4', 'relu3_4', 'pool3',
 
-        'conv3_1', 'relu3_1', 'conv3_2', 'relu3_2', 'conv3_3',
-        'relu3_3', 'conv3_4', 'relu3_4', 'pool3',
+    'conv4_1', 'relu4_1', 'conv4_2', 'relu4_2', 'conv4_3',
+    'relu4_3', 'conv4_4', 'relu4_4', 'pool4',
 
-        'conv4_1', 'relu4_1', 'conv4_2', 'relu4_2', 'conv4_3',
-        'relu4_3', 'conv4_4', 'relu4_4', 'pool4',
+    'conv5_1', 'relu5_1', 'conv5_2', 'relu5_2', 'conv5_3',
+    'relu5_3', 'conv5_4', 'relu5_4'
+)
 
-        'conv5_1', 'relu5_1', 'conv5_2', 'relu5_2', 'conv5_3',
-        'relu5_3', 'conv5_4', 'relu5_4'
-    )
-
+def load_net(data_path):
     data = scipy.io.loadmat(data_path)
     mean = data['normalization'][0][0][0]
     mean_pixel = np.mean(mean, axis=(0, 1))
     weights = data['layers'][0]
+    return weights, mean_pixel
 
+def net_preloaded(weights, input_image):
     net = {}
     current = input_image
-    for i, name in enumerate(layers):
+    for i, name in enumerate(vgg19_layers):
         kind = name[:4]
         if kind == 'conv':
             kernels, bias = weights[i][0][0][0][0]
@@ -43,9 +44,8 @@ def net(data_path, input_image):
             current = _pool_layer(current)
         net[name] = current
 
-    assert len(net) == len(layers)
-    return net, mean_pixel
-
+    assert len(net) == len(vgg19_layers)
+    return net
 
 def _conv_layer(input, weights, bias):
     conv = tf.nn.conv2d(input, tf.constant(weights), strides=(1, 1, 1, 1),


### PR DESCRIPTION
Important highlights:
* https://github.com/avoroshilov/neural-style/commit/12ce208cf4691e545b07b62254ea9762cb65e438 improves JPEG quality (was 75 vs now 95)
* https://github.com/avoroshilov/neural-style/commit/589d8d4335958157b8aacef642417cd33803fe48 adds color-preserving style transfer: approach 2 from "Preserving Color in Neural Artistic Style Transfer", implementation adapted from github.com/pavelgonchar/color-independent-style-transfer
* https://github.com/avoroshilov/neural-style/commit/674951226fac65c3d62b9eab698c6f7aca908c9b adds the ability to tweak layer weights for style transfer, to change the transferred style look
* https://github.com/avoroshilov/neural-style/commit/1621127186dd2d6696385fa6eba91e503572b305 content loss from two layers (relu4_2 and relu5_2) - increasing relu5_2 weight allows for more abstract style transfer (less high-freq content details preserved)
* https://github.com/avoroshilov/neural-style/commit/852089a28454a1ff506201b28430630bbb9f7e8f allows to modify weights of a VGGnet once (this matters when you want to use random, previously it re-generated weights for each net instantiation)
* https://github.com/avoroshilov/neural-style/commit/43ae64597d59cb7f188472f2e327f357c402b3de "A Neural Algorithm of Artistic Style" suggests to replace max pool with avg pool; but my experiments show that this is not always a good thing, but sometimes it is definitely a good thing.

Some examples:

A bit tweaked starry night transfers:
![1-output-tweaked](https://cloud.githubusercontent.com/assets/11299031/22394217/e0df2fd6-e52a-11e6-8a8a-7d71f5ab5d75.jpg)
![1-output-tweaked2](https://cloud.githubusercontent.com/assets/11299031/22394236/8d33de1c-e52b-11e6-977a-d5661983cc0a.jpg)


Color-preserving starry night transfer:
![1-output-preserve](https://cloud.githubusercontent.com/assets/11299031/22394221/f17a89d0-e52a-11e6-843e-2888fa229f28.jpg)
