### PR TITLE
Update stylize.py

### DIFF
--- a/neural_style.py
+++ b/neural_style.py
@@ -30,6 +30,9 @@ def build_parser():
     parser.add_argument('--iterations', type=int,
             dest='iterations', help='iterations',
             metavar='ITERATIONS', default=ITERATIONS)
+    parser.add_argument('--target-loss', type=float,
+            dest='target_loss', help='target loss',
+            metavar='TARGET_LOSS', default = 0.0)
     parser.add_argument('--width', type=int,
             dest='width', help='output width',
             metavar='WIDTH')
@@ -80,11 +83,12 @@ def main():
     if initial is not None:
         initial = scipy.misc.imresize(imread(initial), content_image.shape[:2])
 
-    image = stylize(options.network, initial, content_image, style_image,
+    image, loss = stylize(options.network, initial, content_image, style_image,
             options.iterations, options.content_weight, options.style_weight,
             options.tv_weight, options.learning_rate,
-            print_iter=options.print_iter)
+            print_iter=options.print_iter, target_loss=options.target_loss)
     imsave(options.output, image)
+    print loss
 
 
 def imread(path):

--- a/neural_style.py
+++ b/neural_style.py
@@ -1,19 +1,20 @@
 from stylize import *
 
 import numpy as np
-import scipy.misc as sm
+import scipy.misc
 
 import math
 from argparse import ArgumentParser
 
-# defaults
-VGG_PATH = 'imagenet-vgg-verydeep-19.mat'
+# default arguments
 CONTENT_WEIGHT = 5e0
 STYLE_WEIGHT = 1e2
 TV_WEIGHT = 1e2
 LEARNING_RATE = 1e1
 STYLE_SCALE = 1.0
 ITERATIONS = 1000
+VGG_PATH = 'imagenet-vgg-verydeep-19.mat'
+
 
 def build_parser():
     parser = ArgumentParser()
@@ -53,43 +54,47 @@ def build_parser():
     parser.add_argument('--initial',
             dest='initial', help='initial image',
             metavar='INITIAL')
-    parser.add_argument('--print-iter', type=int,
-            dest='print_iter', help='print statistics after these many iterations',
+    parser.add_argument('--print-iterations', type=int,
+            dest='print_iter', help='statistics printing frequency',
             metavar='PRINT_ITER')
     return parser
+
 
 def main():
     parser = build_parser()
     options = parser.parse_args()
-    width = options.width
-    style_scale = options.style_scale
 
     content_image = imread(options.content)
     style_image = imread(options.style)
 
+    width = options.width
     if width is not None:
         new_shape = (int(math.floor(float(content_image.shape[0]) /
                 content_image.shape[1] * width)), width)
-        content_image = sm.imresize(content_image, new_shape)
+        content_image = scipy.misc.imresize(content_image, new_shape)
     target_shape = content_image.shape
-    style_image = sm.imresize(style_image, style_scale * target_shape[1] /
-            style_image.shape[1])
+    style_image = scipy.misc.imresize(style_image, options.style_scale *
+            target_shape[1] / style_image.shape[1])
 
     initial = options.initial
     if initial is not None:
-        initial = sm.imresize(imread(initial), content_image.shape[:2])
+        initial = scipy.misc.imresize(imread(initial), content_image.shape[:2])
 
     image = stylize(options.network, initial, content_image, style_image,
             options.iterations, options.content_weight, options.style_weight,
-            options.tv_weight, options.learning_rate, print_iter=options.print_iter)
+            options.tv_weight, options.learning_rate,
+            print_iter=options.print_iter)
     imsave(options.output, image)
 
+
 def imread(path):
-    return sm.imread(path).astype(np.float)
+    return scipy.misc.imread(path).astype(np.float)
+
 
 def imsave(path, img):
     img = np.clip(img, 0, 255).astype(np.uint8)
-    sm.imsave(path, img)
+    scipy.misc.imsave(path, img)
+
 
 if __name__ == '__main__':
     main()

--- a/stylize.py
+++ b/stylize.py
@@ -107,7 +107,7 @@ def stylize(network, initial, content, style, iterations,
                             best = image.eval()
                 print_progress(None, i == iterations - 1)
                 i += 1
-            return (vgg.unprocess(best).reshape(shape[1:]), mean_pixel), best_loss)
+            return (vgg.unprocess(best.reshape(shape[1:]), mean_pixel), best_loss)
 
 
 def _tensor_size(tensor):

--- a/stylize.py
+++ b/stylize.py
@@ -3,8 +3,11 @@ import vgg
 import tensorflow as tf
 import numpy as np
 
+from sys import stderr
+
 CONTENT_LAYER = 'relu4_2'
 STYLE_LAYERS = ('relu1_1', 'relu2_1', 'relu3_1', 'relu4_1', 'relu5_1')
+
 
 def stylize(network, initial, content, style, iterations,
         content_weight, style_weight, tv_weight,
@@ -14,6 +17,7 @@ def stylize(network, initial, content, style, iterations,
     content_features = {}
     style_features = {}
 
+    # compute content features in feedforward mode
     g = tf.Graph()
     with g.as_default(), g.device('/cpu:0'), tf.Session() as sess:
         image = tf.placeholder('float', shape=shape)
@@ -22,6 +26,7 @@ def stylize(network, initial, content, style, iterations,
         content_features[CONTENT_LAYER] = net[CONTENT_LAYER].eval(
                 feed_dict={image: content_pre})
 
+    # compute style features in feedforward mode
     g = tf.Graph()
     with g.as_default(), g.device('/cpu:0'), tf.Session() as sess:
         image = tf.placeholder('float', shape=style_shape)
@@ -30,53 +35,69 @@ def stylize(network, initial, content, style, iterations,
         for layer in STYLE_LAYERS:
             features = net[layer].eval(feed_dict={image: style_pre})
             features = np.reshape(features, (-1, features.shape[3]))
-            gram = np.matmul(features.T, features) / (features.size)
+            gram = np.matmul(features.T, features) / features.size
             style_features[layer] = gram
 
+    # make stylized image using backpropogation
     with tf.Graph().as_default():
         if initial is None:
             noise = np.random.normal(size=shape, scale=np.std(content) * 0.1)
-            initial = tf.random_normal(shape) * 256 / 1000
+            initial = tf.random_normal(shape) * 0.256
         else:
             initial = np.array([vgg.preprocess(initial, mean_pixel)])
             initial = initial.astype('float32')
         image = tf.Variable(initial)
         net, _ = vgg.net(network, image)
 
+        # content loss
         content_loss = content_weight * (2 * tf.nn.l2_loss(
                 net[CONTENT_LAYER] - content_features[CONTENT_LAYER]) /
                 content_features[CONTENT_LAYER].size)
+        # style loss
         style_losses = []
-        for i in STYLE_LAYERS:
-            layer = net[i]
+        for style_layer in STYLE_LAYERS:
+            layer = net[style_layer]
             _, height, width, number = map(lambda i: i.value, layer.get_shape())
             size = height * width * number
             feats = tf.reshape(layer, (-1, number))
-            gram = tf.matmul(tf.transpose(feats), feats) / (size)
-            style_gram = style_features[i]
-            style_losses.append(2 * tf.nn.l2_loss(gram - style_gram) / style_gram.size)
+            gram = tf.matmul(tf.transpose(feats), feats) / size
+            style_gram = style_features[style_layer]
+            style_losses.append(2 * tf.nn.l2_loss(gram - style_gram) /
+                    style_gram.size)
         style_loss = style_weight * reduce(tf.add, style_losses)
-        tv_elems = reduce(lambda x, y: x * y, [d.value for d in image[:,1:,:,:].get_shape()], 1)
-        tv_loss = tv_weight * (2 * (tf.nn.l2_loss(image[:,1:,:,:] - image[:,:shape[1]-1,:,:]) +
-            tf.nn.l2_loss(image[:,:,1:,:] - image[:,:,:shape[2]-1,:])) / tv_elems)
+        # total variation denoising
+        tv_y_size = _tensor_size(image[:,1:,:,:])
+        tv_x_size = _tensor_size(image[:,:,1:,:])
+        tv_loss = tv_weight * 2 * (
+                (tf.nn.l2_loss(image[:,1:,:,:] - image[:,:shape[1]-1,:,:]) /
+                    tv_y_size) +
+                (tf.nn.l2_loss(image[:,:,1:,:] - image[:,:,:shape[2]-1,:]) /
+                    tv_x_size))
+        # overall loss
         loss = content_loss + style_loss + tv_loss
 
+        # optimizer setup
         train_step = tf.train.AdamOptimizer(learning_rate).minimize(loss)
 
+        def print_progress(i, last=False):
+            if print_iter is not None:
+                if i is not None and i % print_iter == 0 or last:
+                    print >> stderr, '  content loss: %g' % content_loss.eval()
+                    print >> stderr, '    style loss: %g' % style_loss.eval()
+                    print >> stderr, '       tv loss: %g' % tv_loss.eval()
+                    print >> stderr, '    total loss: %g' % loss.eval()
 
+        # optimization
         with tf.Session() as sess:
-            def print_progress(i, last=False):
-                if print_iter is not None:
-                    if i is not None and i % print_iter == 0 or last:
-                        print '  content loss: %g' % (content_loss.eval())
-                        print '    style loss: %g' % (style_loss.eval())
-                        print '       tv loss: %g' % (tv_loss.eval())
-                        print '    total loss: %g' % loss.eval()
-
             sess.run(tf.initialize_all_variables())
             for i in range(iterations):
                 print_progress(i)
-                print 'Iteration %d/%d' % (i + 1, iterations)
+                print >> stderr, 'Iteration %d/%d' % (i + 1, iterations)
                 train_step.run()
                 print_progress(None, i == iterations - 1)
             return vgg.unprocess(image.eval().reshape(shape[1:]), mean_pixel)
+
+
+def _tensor_size(tensor):
+    from operator import mul
+    return reduce(mul, (d.value for d in tensor.get_shape()), 1)

--- a/stylize.py
+++ b/stylize.py
@@ -89,13 +89,13 @@ def stylize(network, initial, content, style, iterations,
                     print >> stderr, '    total loss: %g' % loss.eval()
 
         # optimization
+        assert checkpoint_iterations is not None # ugly hack cause lazy
         best_loss = float('inf')
         best = None
         with tf.Session() as sess:
             sess.run(tf.initialize_all_variables())
             i = 0
-            curr_loss = float('inf')
-            while i < iterations and curr_loss > target_loss:
+            while i < iterations and best_loss > target_loss:
                 print_progress(i)
                 print >> stderr, 'Iteration %d/%d' % (i + 1, iterations)
                 train_step.run()
@@ -106,11 +106,8 @@ def stylize(network, initial, content, style, iterations,
                             best_loss = this_loss
                             best = image.eval()
                 print_progress(None, i == iterations - 1)
-                if i % 10 == 0:
-                    curr_loss = loss.eval()
                 i += 1
-            return (vgg.unprocess((best or image.eval()).reshape(shape[1:]),
-                    mean_pixel), min(best_loss, loss.eval))
+            return (vgg.unprocess(best).reshape(shape[1:]), mean_pixel), best_loss)
 
 
 def _tensor_size(tensor):

--- a/video
+++ b/video
@@ -15,7 +15,7 @@ i=1
 # process first frame
 filename=$(printf $NAME $i)
 output=$(printf $OUT $i)
-loss=$(python neural_style.py --print-iter $PRINT_ITER --width $WIDTH --style $STYLE_IMAGE --content $filename --output $output --iterations $MAX_ITER)
+loss=$(python neural_style.py --print-iter $PRINT_ITER --width $WIDTH --style $STYLE_IMAGE --content $filename --output $output --iterations $MAX_ITER --checkpoint-iter $CHKPT)
 
 # process rest of the frames
 i=$(($i + 1))
@@ -24,6 +24,6 @@ while [[ $i -lt $NUM ]]; do
     filename=$(printf $NAME $i)
     output=$(printf $OUT $i)
     sleep 5
-    loss=$(python neural_style.py --print-iter $PRINT_ITER --width $WIDTH --style $STYLE_IMAGE --content $filename --initial $prev --output $output --iterations $MAX_ITER --target-loss $loss)
+    loss=$(python neural_style.py --print-iter $PRINT_ITER --width $WIDTH --style $STYLE_IMAGE --content $filename --initial $prev --output $output --iterations $MAX_ITER --target-loss $loss --checkpoint-iter $CHKPT)
     i=$(($i + 1))
 done

--- a/video
+++ b/video
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -eu
+
+NAME='frame%03d.jpg'
+OUT='frame-out%03d.jpg'
+NUM=100
+MAX_ITER=1000
+STYLE_IMAGE='starry_night.jpg'
+WIDTH=600
+PRINT_ITER=25
+
+i=1
+
+# process first frame
+filename=$(printf $NAME $i)
+output=$(printf $OUT $i)
+loss=$(python neural_style.py --print-iter $PRINT_ITER --width $WIDTH --style $STYLE_IMAGE --content $filename --output $output --iterations $MAX_ITER)
+
+# process rest of the frames
+i=$(($i + 1))
+while [[ $i -lt $NUM ]]; do
+    prev=$(printf $OUT $(($i - 1)))
+    filename=$(printf $NAME $i)
+    output=$(printf $OUT $i)
+    sleep 5
+    loss=$(python neural_style.py --print-iter $PRINT_ITER --width $WIDTH --style $STYLE_IMAGE --content $filename --initial $prev --output $output --iterations $MAX_ITER --target-loss $loss)
+    i=$(($i + 1))
+done


### PR DESCRIPTION
In _stylize.py:113_
Changing:
             `sess.run(tf.initialize_all_variables())
`
To:
            `sess.run(tf.global_variables_initializer())
`

Because 
**.initialize_all_variables (from tensorflow.python.ops.variables) is deprecated and will be removed after 2017-03-02.
Instructions for updating:
Use `tf.global_variables_initializer` instead.**