### PR TITLE
Validate output path and filename, fixes #54

### DIFF
--- a/neural_style.py
+++ b/neural_style.py
@@ -112,6 +112,9 @@ def main():
     if not os.path.isfile(options.network):
         parser.error("Network %s does not exist. (Did you forget to download it?)" % options.network)
 
+    if options.output and not is_path_writeable(options.output):
+        parser.error('Output path not writeable: ' + options.output)
+
     content_image = imread(options.content)
     style_images = [imread(style) for style in options.styles]
 
@@ -200,7 +203,19 @@ def imread(path):
 
 def imsave(path, img):
     img = np.clip(img, 0, 255).astype(np.uint8)
-    Image.fromarray(img).save(path, quality=95)
+    im_obj = Image.fromarray(img)
+    try:
+        im_obj.save(path, quality=95)
+    except KeyError:
+        fallback_path = path + '.png'
+        print('Invalid image extension, saving instead to: ' + fallback_path)
+        im_obj.save(fallback_path)
+
+
+def is_path_writeable(path):
+    dirname = os.path.dirname(path)
+    return os.access(dirname, os.W_OK | os.X_OK)
+
 
 if __name__ == '__main__':
     main()

--- a/neural_style.py
+++ b/neural_style.py
@@ -1,16 +1,14 @@
 # Copyright (c) 2015-2017 Anish Athalye. Released under GPLv3.
 
+import math
 import os
+from argparse import ArgumentParser
 
 import numpy as np
 import scipy.misc
+from PIL import Image
 
 from stylize import stylize
-
-import math
-from argparse import ArgumentParser
-
-from PIL import Image
 
 # default arguments
 CONTENT_WEIGHT = 5e0


### PR DESCRIPTION
Fixes #54 

- checks that the output directory is writeable/searchable
- if there's an invalid image file extension, we instead save as a lossless PNG
- optimize imports according to PEP-8