### PR TITLE
tensorflow instead of tensorflow-gpu for requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
 numpy
 Pillow  # provides PIL
 scipy
-tensorflow-gpu >= 1.0  # installs tensorflow with GPU support, should still work even without GPU
+
+# if you have a compatible GPU, you can use tensorflow-gpu to satisfy this requirement
+# https://www.tensorflow.org/install/
+tensorflow >= 1.0 


### PR DESCRIPTION
Per https://github.com/anishathalye/neural-style/issues/74, modified the requirements.txt to explicitly specify `tensorflow`, which can be satisfied by either `tensorflow` or `tensorflow-gpu`.