### PR TITLE
add layered stylize

### DIFF
--- a/neural_style.py
+++ b/neural_style.py
@@ -34,7 +34,7 @@ def build_parser():
             metavar='CONTENT', required=True)
     parser.add_argument('--styles',
             dest='styles',
-            nargs='+', help='one or more style images',
+            nargs='+', help='one to five style images',
             metavar='STYLE', required=True)
     parser.add_argument('--output',
             dest='output', help='output path',
@@ -113,7 +113,16 @@ def main():
         parser.error("Network %s does not exist. (Did you forget to download it?)" % options.network)
 
     content_image = imread(options.content)
-    style_images = [imread(style) for style in options.styles]
+    assert len(options.styles) <= 5
+    styles = options.styles
+    if len(options.styles) < 5:
+        add = 5-len(options.styles)
+        for i in range(add):
+            styles.append(options.styles[-1])
+    print(styles)
+    style_images = [imread(style) for style in styles]
+
+
 
     width = options.width
     if width is not None:

--- a/stylize.py
+++ b/stylize.py
@@ -104,16 +104,14 @@ def stylize(network, initial, initial_noiseblend, content, styles, preserve_colo
         # style loss
         style_loss = 0
         for i in range(len(styles)):
-            style_losses = []
-            for style_layer in STYLE_LAYERS:
-                layer = net[style_layer]
-                _, height, width, number = map(lambda i: i.value, layer.get_shape())
-                size = height * width * number
-                feats = tf.reshape(layer, (-1, number))
-                gram = tf.matmul(tf.transpose(feats), feats) / size
-                style_gram = style_features[i][style_layer]
-                style_losses.append(style_layers_weights[style_layer] * 2 * tf.nn.l2_loss(gram - style_gram) / style_gram.size)
-            style_loss += style_weight * style_blend_weights[i] * reduce(tf.add, style_losses)
+            layer = net[STYLE_LAYERS[i]]
+            _, height, width, number = map(lambda i: i.value, layer.get_shape())
+            size = height * width * number
+            feats = tf.reshape(layer, (-1, number))
+            gram = tf.matmul(tf.transpose(feats), feats) / size
+            style_gram = style_features[i][STYLE_LAYERS[i]]
+            style_losses = (2 * tf.nn.l2_loss(gram - style_gram) / style_gram.size)
+            style_loss += style_weight * style_blend_weights[i] * style_losses
 
         # total variation denoising
         tv_y_size = _tensor_size(image[:,1:,:,:])


### PR DESCRIPTION
You can see why I changed the code and some experiments I did in this page: 
[https://github.com/B-C-WANG/AI.Experiment/tree/master/AI.Exp.LayerNeuralStylize](https://github.com/B-C-WANG/AI.Experiment/tree/master/AI.Exp.LayerNeuralStylize)
We often use one style image to calculate its output from beginning to relu1-1,relu2-1,relu3-1,relu4-1 and relu5-1 in VGG model. Here I split them, means that you can feed with 1 to 5 images to individually calculate its relu1-1, relu2-1, relu3-1, relu4-1 and relu5-1.