### PR TITLE
Set required scipy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy
 Pillow  # provides PIL
-scipy
+scipy=1.1
 tensorflow-gpu >= 1.0  # installs tensorflow with GPU support, should still work even without GPU


### PR DESCRIPTION
Updates `requirements.txt` to specify required version of scipy (starting from scipy 1.2.0, `scipy.misc.imread()` and `scipy.misc.imresize()` have been removed.

Eventually, these could be updated to use imageio / pillow.. 