### PR TITLE
Fixing tensorflow version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy
 Pillow  # provides PIL
 scipy==1.1
-tensorflow-gpu >= 1.0  # installs tensorflow with GPU support, should still work even without GPU
+tensorflow-gpu==1.13.2  # installs tensorflow with GPU support, should still work even without GPU


### PR DESCRIPTION
The current version specifier causes the latest version, 2.0, to get installed and that breaks the code in `vgg.py`