### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM python:3.7-buster
 
 RUN apt-get update
 
-COPY requirements.txt /app/requirements.txt
+COPY requirements.docker.txt /app/requirements.docker.txt
 
-RUN pip install -r /app/requirements.txt
+RUN pip install -r /app/requirements.docker.txt
 
 RUN wget -P /app http://www.vlfeat.org/matconvnet/models/imagenet-vgg-verydeep-19.mat
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.7-buster
+
+RUN apt-get update
+
+COPY requirements.txt /app/requirements.txt
+
+RUN pip install -r /app/requirements.txt
+
+RUN wget -P /app http://www.vlfeat.org/matconvnet/models/imagenet-vgg-verydeep-19.mat
+
+COPY ./*.py /app/
+
+WORKDIR /app
+
+ENTRYPOINT ["python", "/app/neural_style.py"]

--- a/README.md
+++ b/README.md
@@ -129,6 +129,44 @@ list:
 * [SciPy](https://github.com/scipy/scipy/blob/master/INSTALL.rst.txt)
 * [Pillow](http://pillow.readthedocs.io/en/3.3.x/installation.html#installation)
 
+## Requirements
+
+Tool can be used within `docker` image. See [docker.com](https://www.docker.com/get-started) on how to get started with
+containerized applications.
+
+### Building a docker image
+
+With `docker` command-line tool install and ready, run the following command in the root of directory
+to build the docker image for `neural-style`:
+
+```commandline
+docker build -t neural-style .
+```
+
+The command will build image locally and tag it as `neural-style:latest`.
+All `neural-style` dependencies like `Python`, `TensorFlow` and 
+`imagenet-vgg-verydeep` model will be included as part of the build.
+Image build does not include installation and configuration of CUDA, GPU devices
+
+### Using docker image
+
+Once docker image is built, `neural-style` can be run using the following command-line:
+
+```commandline
+docker run -v <examples directory>:/data neural-style --content /data/<content file> 
+--styles /data/<style file> --output /data/<output file>
+```
+
+Where `<examples directory>` is replaced to directory path containing all the sample data and
+mounted to `/data` directory (or any other directory if specified otherwise). From that point, all files will be found 
+under `/data` directory when running the application in docker container
+
+Example command-line: 
+```commandline
+docker run -v /home/user/neural-style/examples:/data neural-style --content /data/1-content.jpg 
+--styles /data/1-style.jpg --output /data/my-output.jpg
+```
+
 ## Citation
 
 If you use this implementation in your work, please cite the following:

--- a/requirements.docker.txt
+++ b/requirements.docker.txt
@@ -1,4 +1,4 @@
-numpy
-Pillow  # provides PIL
+numpy==1.19.5
+Pillow==8.1.0  # provides PIL
 scipy==1.1
 tensorflow-gpu >= 1.0,<2.0  # installs tensorflow with GPU support, should still work even without GPU

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
-Pillow  # provides PIL
+numpy==1.19.5
+Pillow==8.1.0  # provides PIL
 scipy==1.1
 tensorflow-gpu >= 1.0,<2.0  # installs tensorflow with GPU support, should still work even without GPU


### PR DESCRIPTION
`neural-style` can be successfully run as containerised application. `Dockerfile` support was added to go through all setup process with simple docker build. From that point, docker image can be used on any environment supporting docker with no additional setup.

See readme on how to setup and run `neural-style` in docker.

Also, `requirement.txt` dependencies were locked into specific versions to avoid failures in docker builds in the future

ps. GPU support is not included. This may be updated in the future to utilise GPU for better performance