### PR TITLE
removed a singleton comparison pitfall from the code

### DIFF
--- a/stylize.py
+++ b/stylize.py
@@ -206,7 +206,7 @@ def stylize(network, initial, initial_noiseblend, content, styles, preserve_colo
 
                     img_out = vgg.unprocess(best.reshape(shape[1:]), vgg_mean_pixel)
 
-                    if preserve_colors and preserve_colors is True:
+                    if preserve_colors:
                         original_image = np.clip(content, 0, 255)
                         styled_image = np.clip(img_out, 0, 255)
 


### PR DESCRIPTION
**The problem**
In Python when comparing a variable to a singleton value like True, False and None it is advised to use the operator 'is' instead of '=='. This pitfall was detected using Pylint, which indicated it under the code C0121, as seen on the link below
https://vald-phoenix.github.io/pylint-errors/plerr/errors/basic/C0121.html

**The solution**
Just changed the operator